### PR TITLE
Fix/#15

### DIFF
--- a/components/sale/Result.tsx
+++ b/components/sale/Result.tsx
@@ -23,7 +23,9 @@ import {
   getProviderPercentages,
   getProviderSums,
 } from "@/lib/sale/sale";
-import SMGalmegiSummary from "./report/SMGalmegiSummary";
+import SMReport from "./report/SMReport";
+import PromotionStockReport from "./report/PromotionStockReport";
+import OtherCompanyPromotionReport from "./report/OtherCompanyPromotionReport";
 
 type ResultProps = {
   drink: Drink;
@@ -225,87 +227,20 @@ export default function Result({
         {selectedBusinessZone === "수영" && (
           <div>
             <br />
-            <h1>3. 타사 판촉인원 / 판촉물 및 판촉내용</h1>
-            <div>
-              {otherCompanyPromotions.map((promotion, index) => (
-                <p key={`${index}-${promotion.name}`}>
-                  {promotion.name} {promotion.workerNumber || 0}명 /{" "}
-                  {promotion.info}
-                </p>
-              ))}
-            </div>
+            <OtherCompanyPromotionReport
+              otherCompanyPromotions={otherCompanyPromotions}
+            />
             <br />
-            <h1>4. ★자사 판촉물 재고량★ (박스로 기입해서 올려주세요)</h1>
-            <div>
-              {promotionStocks.map((stock, index) => (
-                <p key={`${index}-${stock.name}`}>
-                  &nbsp;- {stock.name} {stock.quantity || 0}박스
-                </p>
-              ))}
-            </div>
+            <PromotionStockReport promotionStocks={promotionStocks} />
           </div>
         )}
         {selectedBusinessZone === "광안" && (
-          <div className="border border-blue-300">
-            <h1>
-              {"<"}이순조SM 퇴근보고{">"}
-            </h1>
-            <section>
-              <h1>1. 야간판촉지역</h1>
-              <p>광안 바닷가</p>
-              <p>총 테이블 수 : {providerSums.total}</p>
-            </section>
-            <section>
-              <h1>2. 야간 음용비</h1>
-              <p>
-                좋은데이 : {reportTables.goodDay}T - {reportPercentages.goodDay}
-                %
-              </p>
-              <p>
-                좋은데이 톡시리즈 : {reportTables.toc}T -{" "}
-                {reportPercentages.toc}%
-              </p>
-              <p>
-                갈매기19 : {reportTables.galmegi19}T -{" "}
-                {reportPercentages.galmegi19}% %
-              </p>
-              <p>
-                갈매기16 : {reportTables.galmegi16}T -{" "}
-                {reportPercentages.galmegi16}%
-              </p>
-              <p>
-                대선 : {reportTables.daesun}T - {reportPercentages.daesun}%
-              </p>
-              <p>
-                강알리 : {reportTables.gangali}T - {reportPercentages.gangali}%
-              </p>
-              <p>
-                진로 : {reportTables.jinro}T - {reportPercentages.jinro}%
-              </p>
-              <p>
-                진로(골드) : {reportTables.jinrogold}T -{" "}
-                {reportPercentages.jinrogold}%
-              </p>
-              <p>
-                참이슬 : {reportTables.chamisul}T - {reportPercentages.chamisul}
-                %
-              </p>
-              <p>C1: T - %</p>
-              <h2>기타</h2>
-              <p>
-                새로: {reportTables.sero}T - {reportPercentages.sero}% %
-              </p>
-              <p>
-                새로(살구): {reportTables.serosalgu}T -{" "}
-                {reportPercentages.serosalgu}%
-              </p>
-              <p>
-                청하: {reportTables.chungha}T - {reportPercentages.chungha}%
-              </p>
-              <br />
-              <SMGalmegiSummary galmegiSums={galmegiSums} />
-            </section>
-          </div>
+          <SMReport
+            providerSums={providerSums}
+            reportTables={reportTables}
+            reportPercentages={reportPercentages}
+            galmegiSums={galmegiSums}
+          />
         )}
         <button
           type="button"

--- a/components/sale/report/OtherCompanyPromotionReport.tsx
+++ b/components/sale/report/OtherCompanyPromotionReport.tsx
@@ -1,0 +1,22 @@
+import { OtherCompanyPromotionResult } from "@/utils/sale/types";
+
+type OtherCompanyPromotionReportProps = {
+  otherCompanyPromotions: OtherCompanyPromotionResult[];
+};
+
+export default function OtherCompanyPromotionReport({
+  otherCompanyPromotions,
+}: OtherCompanyPromotionReportProps) {
+  return (
+    <section>
+      <h1>3. 타사 판촉인원 / 판촉물 및 판촉내용</h1>
+      <div>
+        {otherCompanyPromotions.map((promotion, index) => (
+          <p key={`${index}-${promotion.name}`}>
+            {promotion.name} {promotion.workerNumber || 0}명 / {promotion.info}
+          </p>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/sale/report/PromotionStockReport.tsx
+++ b/components/sale/report/PromotionStockReport.tsx
@@ -1,0 +1,22 @@
+import { PromotionStock } from "@/utils/sale/types";
+
+type PromotionStockReportProps = {
+  promotionStocks: PromotionStock[];
+};
+
+export default function PromotionStockReport({
+  promotionStocks,
+}: PromotionStockReportProps) {
+  return (
+    <section>
+      <h1>4. ★자사 판촉물 재고량★ (박스로 기입해서 올려주세요)</h1>
+      <div>
+        {promotionStocks.map((stock, index) => (
+          <p key={`${index}-${stock.name}`}>
+            &nbsp;- {stock.name} {stock.quantity || 0}박스
+          </p>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/sale/report/SMReport.tsx
+++ b/components/sale/report/SMReport.tsx
@@ -1,0 +1,79 @@
+import {
+  GalmegiSums,
+  ProviderSums,
+  ReportPercentages,
+  ReportTables,
+} from "@/utils/sale/types";
+import SMGalmegiSummary from "./SMGalmegiSummary";
+
+type SMReportProps = {
+  providerSums: ProviderSums;
+  reportTables: ReportTables;
+  reportPercentages: ReportPercentages;
+  galmegiSums: GalmegiSums;
+};
+
+export default function SMReport({
+  providerSums,
+  reportTables,
+  reportPercentages,
+  galmegiSums,
+}: SMReportProps) {
+  return (
+    <div className="border border-blue-300">
+      <h1>
+        {"<"}이순조SM 퇴근보고{">"}
+      </h1>
+      <section>
+        <h1>1. 야간판촉지역</h1>
+        <p>광안 바닷가</p>
+        <p>총 테이블 수 : {providerSums.total}</p>
+      </section>
+      <section>
+        <h1>2. 야간 음용비</h1>
+        <p>
+          좋은데이 : {reportTables.goodDay}T - {reportPercentages.goodDay}%
+        </p>
+        <p>
+          좋은데이 톡시리즈 : {reportTables.toc}T - {reportPercentages.toc}%
+        </p>
+        <p>
+          갈매기19 : {reportTables.galmegi19}T - {reportPercentages.galmegi19}%
+          %
+        </p>
+        <p>
+          갈매기16 : {reportTables.galmegi16}T - {reportPercentages.galmegi16}%
+        </p>
+        <p>
+          대선 : {reportTables.daesun}T - {reportPercentages.daesun}%
+        </p>
+        <p>
+          강알리 : {reportTables.gangali}T - {reportPercentages.gangali}%
+        </p>
+        <p>
+          진로 : {reportTables.jinro}T - {reportPercentages.jinro}%
+        </p>
+        <p>
+          진로(골드) : {reportTables.jinrogold}T - {reportPercentages.jinrogold}
+          %
+        </p>
+        <p>
+          참이슬 : {reportTables.chamisul}T - {reportPercentages.chamisul}%
+        </p>
+        <p>C1: T - %</p>
+        <h2>기타</h2>
+        <p>
+          새로: {reportTables.sero}T - {reportPercentages.sero}% %
+        </p>
+        <p>
+          새로(살구): {reportTables.serosalgu}T - {reportPercentages.serosalgu}%
+        </p>
+        <p>
+          청하: {reportTables.chungha}T - {reportPercentages.chungha}%
+        </p>
+        <br />
+        <SMGalmegiSummary galmegiSums={galmegiSums} />
+      </section>
+    </div>
+  );
+}

--- a/lib/sale/sale.ts
+++ b/lib/sale/sale.ts
@@ -54,7 +54,7 @@ export const calculateAdjustedPercentages = (
 
     // 가장 작은 값부터 +-0.1 더하기
     let i = 0;
-    while (Math.abs(diff) > 0.001) {
+    while (allPercentages.length > 0 && Math.abs(diff) > 0.001) {
       // 부동소수점 오차를 고려한 종료 조건
       const [company, index] = allPercentages[i % allPercentages.length];
 
@@ -113,8 +113,8 @@ export const getGalmegiSums = (
 ) => {
   const originalGalmegi19Num = drink["Muhak"][3] || 0;
   const originalGalmegi16Num = drink["Muhak"][4] || 0;
-  const galmegi19OrderNum = orderSums[3] + additionalOrderSums[3];
-  const galmegi16OrderNum = orderSums[4] + additionalOrderSums[4];
+  const galmegi19OrderNum = orderSums[3] + additionalOrderSums[3] || 0;
+  const galmegi16OrderNum = orderSums[4] + additionalOrderSums[4] || 0;
   return {
     original19: originalGalmegi19Num,
     original16: originalGalmegi16Num,

--- a/utils/sale/types.ts
+++ b/utils/sale/types.ts
@@ -47,3 +47,35 @@ export type PromotionStock = {
   name: string;
   quantity: number | undefined;
 };
+
+export type ReportTables = {
+  goodDay: number;
+  toc: number;
+  galmegi19: number;
+  galmegi16: number;
+  daesun: number;
+  gangali: number;
+  daesunEtc: number;
+  chamisul: number;
+  jinro: number;
+  jinrogold: number;
+  sero: number;
+  serosalgu: number;
+  chungha: number;
+};
+
+export type ReportPercentages = {
+  goodDay: string | number;
+  toc: string | number;
+  galmegi19: string | number;
+  galmegi16: string | number;
+  daesun: string | number;
+  gangali: string | number;
+  daesunEtc: string | number;
+  chamisul: string | number;
+  jinro: string | number;
+  jinrogold: string | number;
+  sero: string | number;
+  serosalgu: string | number;
+  chungha: string | number;
+};


### PR DESCRIPTION
- #15 

sale.ts의 L57:74의 오차 수정 로직을 시작하는 조건으로 `allPercentages`에 원소가 하나라도 있어야 함을 추가했습니다.
만약 빈 배열이라면 오차 조정을 할 필요없이 각 value가 undefined인 `newPercentages`를 반환하면 됩니다.

하지만 `drink`와 `newPercentages` 모두 value 타입으로 undefined가 될 수 없기 때문에 근본적인 해결이 필요합니다.

추가로 Result 컴포넌트에서 담당자 보고, 타사 판촉 정보, 자사 판촉물 재고 보고를 각각 컴포넌트로 분리했습니다. 